### PR TITLE
Add local.settings.json for local development

### DIFF
--- a/OrderProcessor/local.settings.json
+++ b/OrderProcessor/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `local.settings.json` with Azurite emulator settings for local development.

## What's included

`OrderProcessor/local.settings.json` with:
- `AzureWebJobsStorage: UseDevelopmentStorage=true` (Azurite emulator)
- `FUNCTIONS_WORKER_RUNTIME: dotnet-isolated`

## Context

Tracked by Azure/azure-functions-templates — ensuring all manifest templates have `local.settings.json` for local development per review feedback on PR #1753.
